### PR TITLE
Take no exit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "take_mut"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["Sgeo <sgeoster@gmail.com>"]
 license = "MIT"
 homepage = "https://github.com/Sgeo/take_mut"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,6 @@ homepage = "https://github.com/Sgeo/take_mut"
 repository = "https://github.com/Sgeo/take_mut"
 description = "Take a T from a &mut T temporarily"
 documentation = "https://crates.fyi/crates/take_mut/0.1.3/"
+
+[dependencies]
+unreachable="0.1.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,13 +73,11 @@ pub fn take_no_exit<T, F>(mut_ref: &mut T, closure: F)
   where T: Sentinel,
         F: FnOnce(T) -> T {
     use std::mem::replace;
-    exit_on_panic(|| {
-        unsafe {
-            let old_t = replace(mut_ref, Sentinel::new_sentinel());
-            let new_t = closure(old_t);
-            replace(mut_ref, new_t).release_sentinel();
-        }
-    });
+    unsafe {
+        let old_t = replace(mut_ref, Sentinel::new_sentinel());
+        let new_t = closure(old_t);
+        replace(mut_ref, new_t).release_sentinel();
+    }
 }
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,13 @@
-//! This crate provides (at this time) a single function, `take()`.
+//! This crate provides function, `take()`.
 //!
 //! `take()` allows for taking `T` out of a `&mut T`, doing anything with it including consuming it, and producing another `T` to put back in the `&mut T`.
 //!
 //! During `take()`, if a panic occurs, the entire process will be exited, as there's no valid `T` to put back into the `&mut T`.
 //!
 //! Contrast with `std::mem::replace()`, which allows for putting a different `T` into a `&mut T`, but requiring the new `T` to be available before being able to consume the old `T`.
+//!
+//! The crate also provides `take_no_exit()` function, which behaves similarly but instead of exiting
+//! the program on panic, it leaves a sentinel value there.
 
 extern crate unreachable;
 
@@ -64,6 +67,8 @@ impl<T> Sentinel for Option<T> {
     }
 }
 
+/// This function is similar to `take()` but instead of exiting, it will leave sentinel value in
+/// place of the original in case of panic.
 pub fn take_no_exit<T, F>(mut_ref: &mut T, closure: F)
   where T: Sentinel,
         F: FnOnce(T) -> T {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,8 @@ pub trait Sentinel: Sized {
     /// Releases the sentinel. Calling this indicates that nothing unexpected happened.
     /// The caller must make sure that the value this function is called with is the exact same
     /// value the `new_sentinel()` funtion returned.
-    unsafe fn release_sentinel(self);
+    unsafe fn release_sentinel(self) {
+    }
 }
 
 impl<T> Sentinel for Option<T> {


### PR DESCRIPTION
These changes add `take_no_exit()` function which uses sentinel value instead of exiting.