### PR TITLE
Include documentation URL in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,4 +6,5 @@ license = "MIT"
 homepage = "https://github.com/Sgeo/take_mut"
 repository = "https://github.com/Sgeo/take_mut"
 description = "Take a T from a &mut T temporarily"
+documentation = "https://docs.rs/take_mut"
 categories = ["rust-patterns"]


### PR DESCRIPTION
Seems like crates.io uses a documentation URL from an old version if no link is specified. Due to that, a documentation link needs to be included.